### PR TITLE
Add ModelNotFoundException as input to missing closure

### DIFF
--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -41,7 +41,11 @@ class SubstituteBindings
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {
-                return $route->getMissing()($request);
+                $missing = $route->getMissing()($request, $exception);
+                
+                if ($missing) {
+                    return $missing;
+                }
             }
 
             throw $exception;


### PR DESCRIPTION
This PR passes the `ModelNotFoundException` exception to the callback registered with the routes `missing()` and only return the result of the callback if this is not present.

Note that the `missing()` method was created in https://github.com/laravel/framework/pull/36035 and made available in Laravel v8.26.0.

## Motivation
The `missing()` method (documented [here](https://laravel.com/docs/master/routing#customizing-missing-model-behavior)) offers a great way to handle any missing implicitly bound models, but there might be cases where one would like to only handle some missing models differently - and that is now possible i with this PR.

Expanding on the original example from ??:

```php
Route::get('/locations/{location:slug}/photos/{photo}', [LocationsController::class, 'show'])
    ->name('locations.view')
    ->missing(fn ($request, $exception) => $exception->getModel() == 'App\Models\Location' ? Redirect::route('locations.index', null, 301) : null);
```
Now this will only redirect the user if the `slug` provided for the `Location` model is not found. If an invalid `photo` is provided a normal ModelNotFound exception would be thrown and handled normally.

